### PR TITLE
Update project to JDK 24

### DIFF
--- a/gym-fees-backend/Dockerfile
+++ b/gym-fees-backend/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17-jre as builder
+FROM eclipse-temurin:24-jre as builder
 WORKDIR /app
 COPY . .
 RUN ./mvnw -q -pl gym-fees-web -am package
 
-FROM gcr.io/distroless/java17
+FROM eclipse-temurin:24-jre
 WORKDIR /app
 COPY --from=builder /app/gym-fees-web/target/gym-fees-web-*.jar app.jar
 ENTRYPOINT ["/app/app.jar"]

--- a/gym-fees-backend/pom.xml
+++ b/gym-fees-backend/pom.xml
@@ -22,7 +22,7 @@
     </dependencies>
   </dependencyManagement>
   <properties>
-    <java.version>17</java.version>
+    <java.version>24</java.version>
     <mapstruct.version>1.6.0.Final</mapstruct.version>
   </properties>
   <build>


### PR DESCRIPTION
## Summary
- update Maven build to target JDK 24
- use Eclipse Temurin JDK 24 images in backend Dockerfile

## Testing
- `./mvnw -q -pl gym-fees-web -am package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fa0c0406c83279fbdcc336636b0cf