### PR TITLE
Add repo-splitting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ archives of the backend and frontend projects are provided separately.
 * `gym-fees-frontend/` – Angular frontend project
 
 Each project includes a README with instructions.
+
+## Splitting into standalone repositories
+
+Run `scripts/split-into-repos.sh` to generate two separate Git repositories with
+full history for the backend and frontend. The script will create
+`../backend-repo` and `../frontend-repo` directories one level above this
+project directory.

--- a/scripts/split-into-repos.sh
+++ b/scripts/split-into-repos.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Split backend and frontend directories into standalone repos using git subtree.
+# Creates ../backend-repo and ../frontend-repo directories with full history.
+
+BACKEND_PREFIX="gym-fees-backend"
+FRONTEND_PREFIX="gym-fees-frontend"
+
+# Backend
+if git rev-parse --verify backend-temp >/dev/null 2>&1; then
+  git branch -D backend-temp
+fi
+
+git subtree split --prefix="$BACKEND_PREFIX" -b backend-temp
+mkdir -p ../backend-repo
+cd ../backend-repo
+git init
+git pull ../onBoardDomain backend-temp
+git branch -m main
+cd ../onBoardDomain
+git branch -D backend-temp
+
+# Frontend
+if git rev-parse --verify frontend-temp >/dev/null 2>&1; then
+  git branch -D frontend-temp
+fi
+
+git subtree split --prefix="$FRONTEND_PREFIX" -b frontend-temp
+mkdir -p ../frontend-repo
+cd ../frontend-repo
+git init
+git pull ../onBoardDomain frontend-temp
+git branch -m main
+cd ../onBoardDomain
+git branch -D frontend-temp
+
+
+echo "Backend repo created at ../backend-repo"
+echo "Frontend repo created at ../frontend-repo"


### PR DESCRIPTION
## Summary
- add `split-into-repos.sh` helper script for splitting backend and frontend
- document the script usage in README

## Testing
- `git status --short`
- `cd ../backend-repo && git log --oneline -n 2`
- `cd ../frontend-repo && git log --oneline -n 2`

------
https://chatgpt.com/codex/tasks/task_e_6884a10cc2808327abf9c7ad330bd835