### PR TITLE
Add simple toggleable security setup

### DIFF
--- a/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/config/SecurityConfig.java
+++ b/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.example.gym.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Value("${app.security.mode:open}")
+    private String securityMode;
+
+    @Value("${app.security.username:admin}")
+    private String username;
+
+    @Value("${app.security.password:admin123}")
+    private String password;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable());
+
+        if ("open".equalsIgnoreCase(securityMode)) {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        } else {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .httpBasic(Customizer.withDefaults());
+        }
+
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        UserDetails user = User.withUsername(username)
+            .password(passwordEncoder.encode(password))
+            .roles("USER")
+            .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/gym-fees-backend/gym-fees-web/src/main/resources/application.properties
+++ b/gym-fees-backend/gym-fees-web/src/main/resources/application.properties
@@ -11,3 +11,9 @@ springdoc.swagger-ui.path=/swagger-ui.html
 
 logging.level.org.springframework=INFO
 spring.flyway.enabled=false
+
+# Security mode: open or secured
+app.security.mode=open
+# Fixed credentials for secured mode
+app.security.username=admin
+app.security.password=admin123


### PR DESCRIPTION
## Summary
- add a `SecurityConfig` that toggles between open and secured modes
- add related properties to `application.properties`

## Testing
- `mvnw -q -pl gym-fees-web -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6884a4b256708327889ea797296bf69c