### PR TITLE
Add Angular route forwarding and error handler

### DIFF
--- a/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/web/AppErrorController.java
+++ b/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/web/AppErrorController.java
@@ -1,0 +1,55 @@
+package com.example.gym.web;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.web.error.ErrorAttributeOptions;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
+/**
+ * Basic /error handler that returns a friendly JSON message for common errors.
+ */
+@Controller
+public class AppErrorController implements ErrorController {
+
+    private final ErrorAttributes errorAttributes;
+
+    public AppErrorController(ErrorAttributes errorAttributes) {
+        this.errorAttributes = errorAttributes;
+    }
+
+    @RequestMapping("/error")
+    public ResponseEntity<Map<String, Object>> handleError(HttpServletRequest request) {
+        HttpStatus status = getStatus(request);
+        Map<String, Object> body = errorAttributes.getErrorAttributes(request,
+                ErrorAttributeOptions.of(ErrorAttributeOptions.Include.MESSAGE));
+        body.put("message", friendlyMessage(status));
+        return new ResponseEntity<>(body, status);
+    }
+
+    private HttpStatus getStatus(HttpServletRequest request) {
+        Object statusCode = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        if (statusCode == null) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        try {
+            return HttpStatus.valueOf(Integer.parseInt(statusCode.toString()));
+        } catch (Exception ex) {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    private String friendlyMessage(HttpStatus status) {
+        return switch (status) {
+            case NOT_FOUND -> "Resource not found";
+            case INTERNAL_SERVER_ERROR -> "Internal server error";
+            default -> "Unexpected error";
+        };
+    }
+}

--- a/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/web/SpaForwardingController.java
+++ b/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/web/SpaForwardingController.java
@@ -1,0 +1,16 @@
+package com.example.gym.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Forwards any unmapped paths (except those containing a period) to the
+ * application index.html so that Angular can handle the routing.
+ */
+@Controller
+public class SpaForwardingController {
+    @RequestMapping(value = {"/{path:[^\\.]*}", "/**/{path:[^\\.]*}"})
+    public String forward() {
+        return "forward:/index.html";
+    }
+}

--- a/gym-fees-backend/gym-fees-web/src/main/resources/static/index.html
+++ b/gym-fees-backend/gym-fees-web/src/main/resources/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Gym Fees App</title>
+</head>
+<body>
+    <h1>Gym Fees SPA</h1>
+    <p>This is the placeholder index page served by Spring Boot.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- forward unknown paths to `index.html` so Angular routing works
- add custom `/error` controller returning friendly JSON messages
- include placeholder `index.html` for the SPA

## Testing
- `mvn -q -pl gym-fees-web package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884a66e05888327bb3eb3c228535b9f