### PR TITLE
Fix MapStruct configuration and dependencies

### DIFF
--- a/gym-fees-backend/gym-fees-application/pom.xml
+++ b/gym-fees-backend/gym-fees-application/pom.xml
@@ -17,5 +17,9 @@
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/gym-fees-backend/pom.xml
+++ b/gym-fees-backend/pom.xml
@@ -92,6 +92,16 @@
                 <artifactId>mapstruct-processor</artifactId>
                 <version>${mapstruct.version}</version>
               </path>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.32</version>
+              </path>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-mapstruct-binding</artifactId>
+                <version>0.2.0</version>
+              </path>
             </annotationProcessorPaths>
           </configuration>
         </plugin>


### PR DESCRIPTION
## Summary
- configure annotation processors so Lombok works with MapStruct
- make `gym-fees-application` depend on Spring Context for `@Component`

## Testing
- `mvn -q -DskipTests=false -pl gym-fees-web -am test` *(fails: Non‑resolvable import POM)*
- `mvn -q -pl gym-fees-application -am package` *(fails: Non‑resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6885f2fea1ac8327af65aa9ebad0c78a