### PR TITLE
Fix ReminderServiceImpl import

### DIFF
--- a/gym-fees-backend/gym-fees-infrastructure/src/main/java/com/example/gym/infrastructure/ReminderServiceImpl.java
+++ b/gym-fees-backend/gym-fees-infrastructure/src/main/java/com/example/gym/infrastructure/ReminderServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -40,9 +39,9 @@ public class ReminderServiceImpl implements ReminderService {
     @Scheduled(cron = "0 0 8 * * *")
     public void markOverdue() {
         LocalDate today = LocalDate.now();
-        subscriptionRepository.findByEndDateBeforeAndStatusNot(today, Subscription.Status.OVERDUE)
+        subscriptionRepository.findByEndDateBeforeAndStatusNot(today, SubscriptionEntity.Status.OVERDUE)
                 .forEach(sub -> {
-                    sub.setStatus(Subscription.Status.OVERDUE);
+                    sub.setStatus(SubscriptionEntity.Status.OVERDUE);
                     subscriptionRepository.save(sub);
                     overdueQueue.add("Subscription " + sub.getId() + " overdue");
                 });


### PR DESCRIPTION
## Summary
- fix incorrect import references in ReminderServiceImpl
- use SubscriptionEntity.Status for overdue logic

## Testing
- `mvn -q clean install` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885f5e7b2e88327aa7873fb02a539bc