### PR TITLE
Fix H2 startup with schema initialization

### DIFF
--- a/gym-fees-backend/gym-fees-web/pom.xml
+++ b/gym-fees-backend/gym-fees-web/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>3.2.5</version> 
+        <version>3.5.3</version>
       </plugin>
 
       <!-- 🔑 NEW: skip all tests so the build succeeds instantly -->

--- a/gym-fees-backend/gym-fees-web/src/main/resources/application-dev.properties
+++ b/gym-fees-backend/gym-fees-web/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=update

--- a/gym-fees-backend/gym-fees-web/src/main/resources/application.properties
+++ b/gym-fees-backend/gym-fees-web/src/main/resources/application.properties
@@ -3,7 +3,9 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
-spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=classpath:data.sql
 spring.h2.console.enabled=true
 
 springdoc.api-docs.path=/v3/api-docs

--- a/gym-fees-backend/gym-fees-web/src/main/resources/schema.sql
+++ b/gym-fees-backend/gym-fees-web/src/main/resources/schema.sql
@@ -1,0 +1,42 @@
+CREATE TABLE members (
+    id UUID PRIMARY KEY,
+    full_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255),
+    mobile VARCHAR(50),
+    photo_url VARCHAR(255),
+    notes VARCHAR(255),
+    archived BOOLEAN NOT NULL,
+    created_at TIMESTAMP
+);
+
+CREATE TABLE packages (
+    id BIGINT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    duration_months INT NOT NULL,
+    base_fee DECIMAL(10,2) NOT NULL
+);
+
+CREATE TABLE subscriptions (
+    id UUID PRIMARY KEY,
+    member_id UUID NOT NULL,
+    package_id BIGINT NOT NULL,
+    start_date DATE,
+    end_date DATE,
+    agreed_fee DECIMAL(10,2),
+    status VARCHAR(20),
+    CONSTRAINT fk_subscription_member FOREIGN KEY (member_id)
+        REFERENCES members(id),
+    CONSTRAINT fk_subscription_package FOREIGN KEY (package_id)
+        REFERENCES packages(id)
+);
+
+CREATE TABLE payments (
+    id UUID PRIMARY KEY,
+    subscription_id UUID NOT NULL,
+    paid_amount DECIMAL(10,2),
+    paid_on DATE,
+    refunded_amount DECIMAL(10,2),
+    refund_reason VARCHAR(255),
+    CONSTRAINT fk_payment_subscription FOREIGN KEY (subscription_id)
+        REFERENCES subscriptions(id)
+);


### PR DESCRIPTION
## Summary
- supply database schema for local dev
- allow automatic schema+data loading
- move Hibernate auto-ddl to dev profile
- update Spring Boot plugin

## Testing
- `mvn -f gym-fees-backend/pom.xml -q -pl gym-fees-web package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688605272c288327a8cd1f3a180471dc