### PR TITLE
refactor: use domain module in web

### DIFF
--- a/gym-fees-backend/gym-fees-domain/src/main/java/com/example/gym/domain/Subscription.java
+++ b/gym-fees-backend/gym-fees-domain/src/main/java/com/example/gym/domain/Subscription.java
@@ -1,19 +1,12 @@
 package com.example.gym.domain;
 
-import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-@Entity
-@Table(name = "subscriptions")
 public class Subscription {
+        private Long id;
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
-	@Column(name = "agreed_fee", nullable = false)
-	private BigDecimal agreedFee;
+        private BigDecimal agreedFee;
 
 	private LocalDate startDate;
 	private LocalDate endDate;

--- a/gym-fees-backend/gym-fees-web/pom.xml
+++ b/gym-fees-backend/gym-fees-web/pom.xml
@@ -20,6 +20,11 @@
       <artifactId>gym-fees-infrastructure</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>gym-fees-domain</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Spring MVC / Web -->
     <dependency>

--- a/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/web/GymFeesApplication.java
+++ b/gym-fees-backend/gym-fees-web/src/main/java/com/example/gym/web/GymFeesApplication.java
@@ -8,7 +8,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.example.gym")
 @EnableJpaRepositories(basePackages = "com.example.gym.infrastructure")
-@EntityScan(basePackages = "com.example.gym.domain")
+@EntityScan(basePackages = "com.example.gym.domain.entity")
 @EnableScheduling
 public class GymFeesApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- remove duplicate Subscription entity by using the domain module in the web app
- link gym-fees-web to gym-fees-domain
- scan only entity package to avoid duplicate mappings
- simplify domain Subscription to a plain class

## Testing
- `mvn -q -f gym-fees-backend/pom.xml clean package` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f66dd21b08327aa2d8f7f16fd7bd8