### PR TITLE
feat: modernize members ui with angular material

### DIFF
--- a/gym-fees-frontend/src/app/app.module.ts
+++ b/gym-fees-frontend/src/app/app.module.ts
@@ -12,6 +12,9 @@ import { MatCardModule } from '@angular/material/card';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
@@ -43,6 +46,9 @@ import { AppComponent } from './app.component';
     MatDialogModule,
     MatSnackBarModule,
     MatProgressSpinnerModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatTooltipModule,
     MatDatepickerModule,
     MatNativeDateModule,
     MatSelectModule,

--- a/gym-fees-frontend/src/app/members/members.component.html
+++ b/gym-fees-frontend/src/app/members/members.component.html
@@ -1,27 +1,48 @@
-<mat-card>
-  <button mat-raised-button color="primary" (click)="add()">Add Member</button>
-  <table mat-table [dataSource]="members" class="mat-elevation-z8 w-100">
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef>Name</th>
-      <td mat-cell *matCellDef="let m">{{m.fullName}}</td>
-    </ng-container>
-    <ng-container matColumnDef="email">
-      <th mat-header-cell *matHeaderCellDef>Email</th>
-      <td mat-cell *matCellDef="let m">{{m.email}}</td>
-    </ng-container>
-    <ng-container matColumnDef="mobile">
-      <th mat-header-cell *matHeaderCellDef>Mobile</th>
-      <td mat-cell *matCellDef="let m">{{m.mobile}}</td>
-    </ng-container>
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let m">
-        <button mat-icon-button (click)="edit(m)">edit</button>
-        <button mat-icon-button color="warn" (click)="remove(m)">delete</button>
-      </td>
-    </ng-container>
-    <tr mat-header-row *matHeaderRowDef="['name','email','mobile','actions']"></tr>
-    <tr mat-row *matRowDef="let row; columns: ['name','email','mobile','actions'];"></tr>
-  </table>
-  <mat-progress-spinner *ngIf="loading" mode="indeterminate"></mat-progress-spinner>
+<mat-toolbar color="primary" class="app-toolbar">
+  <span class="title">Gym Fees App</span>
+</mat-toolbar>
+
+<mat-card class="members-card">
+  <div class="card-header">
+    <button mat-raised-button color="accent" (click)="add()" matTooltip="Add Member">
+      <mat-icon>person_add</mat-icon>
+      <span>Add Member</span>
+    </button>
+  </div>
+
+  <div class="table-wrapper">
+    <table mat-table [dataSource]="dataSource" class="mat-elevation-z2 members-table">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let m">{{ m.fullName }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="email">
+        <th mat-header-cell *matHeaderCellDef>Email</th>
+        <td mat-cell *matCellDef="let m">{{ m.email }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="mobile">
+        <th mat-header-cell *matHeaderCellDef>Mobile</th>
+        <td mat-cell *matCellDef="let m">{{ m.mobile }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>Action</th>
+        <td mat-cell *matCellDef="let m">
+          <button mat-icon-button color="primary" (click)="edit(m)" matTooltip="Edit Member">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-icon-button color="warn" (click)="remove(m)" matTooltip="Delete Member">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+    </table>
+  </div>
+
+  <mat-spinner *ngIf="loading" diameter="40"></mat-spinner>
 </mat-card>

--- a/gym-fees-frontend/src/app/members/members.component.scss
+++ b/gym-fees-frontend/src/app/members/members.component.scss
@@ -1,0 +1,42 @@
+.app-toolbar {
+  justify-content: center;
+  .title {
+    font-weight: 600;
+  }
+}
+
+.members-card {
+  margin: 16px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.card-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.members-table {
+  width: 100%;
+
+  th, td {
+    padding: 12px 16px;
+  }
+
+  tr:nth-child(even) {
+    background: #f5f5f5;
+  }
+}
+
+@media (max-width: 600px) {
+  .members-table th,
+  .members-table td {
+    padding: 8px;
+    font-size: 12px;
+  }
+}

--- a/gym-fees-frontend/src/app/members/members.component.ts
+++ b/gym-fees-frontend/src/app/members/members.component.ts
@@ -4,8 +4,11 @@ import { MemberService, Member } from '../services/member.service';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCardModule } from '@angular/material/card';
-import { MatTableModule } from '@angular/material/table';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MemberDialogComponent } from './member-dialog.component';
 
@@ -14,18 +17,23 @@ import { MemberDialogComponent } from './member-dialog.component';
   selector: 'app-members',
   imports: [
     CommonModule,
+    MatToolbarModule,
     MatCardModule,
     MatTableModule,
     MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
     MatDialogModule,
     MatSnackBarModule,
     MatProgressSpinnerModule,
     MemberDialogComponent
   ],
-  templateUrl: './members.component.html'
+  templateUrl: './members.component.html',
+  styleUrls: ['./members.component.scss']
 })
 export class MembersComponent implements OnInit {
-  members: Member[] = [];
+  dataSource = new MatTableDataSource<Member>();
+  displayedColumns: string[] = ['name', 'email', 'mobile', 'actions'];
   loading = false;
 
   constructor(private memberService: MemberService,
@@ -39,8 +47,8 @@ export class MembersComponent implements OnInit {
   load() {
     this.loading = true;
     this.memberService.getMembers().subscribe({
-      next: d => this.members = d,
-      error: () => this.snack.open('Failed to load members', 'Close'),
+      next: d => this.dataSource.data = d,
+      error: () => this.snack.open('Failed to load members', 'Close', { duration: 3000 }),
       complete: () => this.loading = false
     });
   }
@@ -51,7 +59,7 @@ export class MembersComponent implements OnInit {
       if (result) {
         this.memberService.create(result).subscribe({
           next: () => { this.snack.open('Saved', 'Close', {duration:2000}); this.load(); },
-          error: () => this.snack.open('Save failed', 'Close')
+          error: () => this.snack.open('Save failed', 'Close', { duration: 3000 })
         });
       }
     });
@@ -63,7 +71,7 @@ export class MembersComponent implements OnInit {
       if (result) {
         this.memberService.update(member.id, result).subscribe({
           next: () => { this.snack.open('Updated', 'Close', {duration:2000}); this.load(); },
-          error: () => this.snack.open('Update failed', 'Close')
+          error: () => this.snack.open('Update failed', 'Close', { duration: 3000 })
         });
       }
     });
@@ -73,7 +81,7 @@ export class MembersComponent implements OnInit {
     if (confirm('Delete member?')) {
       this.memberService.delete(member.id).subscribe({
         next: () => { this.snack.open('Deleted', 'Close', {duration:2000}); this.load(); },
-        error: () => this.snack.open('Delete failed', 'Close')
+        error: () => this.snack.open('Delete failed', 'Close', { duration: 3000 })
       });
     }
   }


### PR DESCRIPTION
## Summary
- add toolbar, card layout, and icon-based actions for members page
- integrate MatTableDataSource and angular material modules for members component
- style members page with responsive layout and alternating row colors

## Testing
- `npm test` *(frontend)*: **failed** (missing tsconfig.spec.json)
- `mvn -q test` *(backend)*: **failed** (unresolvable Maven dependencies)


------
https://chatgpt.com/codex/tasks/task_e_688f712be6188327a3ee1aac7bcffe0e