### PR TITLE
fix: clean Angular templates and imports

### DIFF
--- a/gym-fees-frontend/src/app/app.component.html
+++ b/gym-fees-frontend/src/app/app.component.html
@@ -1,0 +1,8 @@
+<mat-toolbar color="primary" class="app-toolbar">
+  <span class="title">Gym Fees App</span>
+  <span class="spacer"></span>
+  <a mat-button routerLink="/members">Members</a>
+</mat-toolbar>
+<div class="content">
+  <router-outlet></router-outlet>
+</div>

--- a/gym-fees-frontend/src/app/app.component.ts
+++ b/gym-fees-frontend/src/app/app.component.ts
@@ -1,35 +1,18 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   standalone: true,
   selector: 'app-root',
-  imports: [RouterModule, MatToolbarModule],
-  template: `
-    <mat-toolbar color="primary" class="app-toolbar">
-      <span class="title">Gym Fees App</span>
-    </mat-toolbar>
-    <div class="content">
-      <router-outlet></router-outlet>
-    </div>
-  `,
+  imports: [RouterModule, MatToolbarModule, MatButtonModule],
+  templateUrl: './app.component.html',
   styles: [
     `.app-toolbar { justify-content: center; }`,
     `.title { font-weight: 600; }`,
+    `.spacer { flex: 1 1 auto; }`,
     `.content { padding: 16px; }`
   ]
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-      <div class="container-fluid">
-        <a class="navbar-brand" routerLink="/">Gym Fees App</a>
-        <div class="navbar-nav">
-          <a class="nav-link" routerLink="/members">Members</a>
-        </div>
-      </div>
-    </nav>
-    <div class="container my-4">
-      <router-outlet></router-outlet>
-    </div>
-  `
 })
-export class AppComponent { }
+export class AppComponent {}

--- a/gym-fees-frontend/src/app/app.module.ts
+++ b/gym-fees-frontend/src/app/app.module.ts
@@ -15,13 +15,9 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatCardModule } from '@angular/material/card';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AppRoutingModule } from './app-routing.module';
 import { MembersComponent } from './members/members.component';
 import { MemberDialogComponent } from './members/member-dialog.component';
@@ -53,13 +49,9 @@ import { AppComponent } from './app.component';
     MatDatepickerModule,
     MatNativeDateModule,
     MatSelectModule,
-    MatToolbarModule,
     MatButtonModule,
-    MatIconModule,
     MatTableModule,
-    MatTooltipModule,
     MatCardModule,
-    MatProgressSpinnerModule,
     AppRoutingModule,
     AppComponent,
     MembersComponent,

--- a/gym-fees-frontend/src/app/members/members.component.html
+++ b/gym-fees-frontend/src/app/members/members.component.html
@@ -1,49 +1,3 @@
-<div class="d-flex justify-content-end mb-3">
-  <button class="btn btn-success" (click)="add()">
-    <i class="bi bi-plus-lg me-1"></i>
-    Add Member
-  </button>
-</div>
-
-<div class="card shadow-sm">
-  <div class="card-body p-0">
-    <div class="table-responsive">
-      <table class="table table-striped table-hover mb-0 align-middle">
-        <thead class="table-light">
-          <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Mobile</th>
-            <th class="text-end">Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let m of members">
-            <td>{{ m.fullName }}</td>
-            <td>{{ m.email }}</td>
-            <td>{{ m.mobile }}</td>
-            <td class="text-end">
-              <button class="btn btn-sm btn-outline-secondary me-2" (click)="edit(m)">
-                <i class="bi bi-pencil"></i>
-              </button>
-              <button class="btn btn-sm btn-outline-danger" (click)="remove(m)">
-                <i class="bi bi-trash"></i>
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</div>
-
-<div class="text-center my-4" *ngIf="loading">
-  <div class="spinner-border text-primary" role="status"></div>
-</div>
-<mat-toolbar color="primary" class="app-toolbar">
-  <span class="title">Gym Fees App</span>
-</mat-toolbar>
-
 <mat-card class="members-card">
   <div class="card-header">
     <button mat-raised-button color="accent" (click)="add()" matTooltip="Add Member">
@@ -87,5 +41,4 @@
   </div>
 
   <mat-spinner *ngIf="loading" diameter="40"></mat-spinner>
-</mat-card>
 </mat-card>

--- a/gym-fees-frontend/src/app/members/members.component.ts
+++ b/gym-fees-frontend/src/app/members/members.component.ts
@@ -6,7 +6,6 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
-import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -17,7 +16,6 @@ import { MemberDialogComponent } from './member-dialog.component';
   selector: 'app-members',
   imports: [
     CommonModule,
-    MatToolbarModule,
     MatCardModule,
     MatTableModule,
     MatButtonModule,
@@ -31,6 +29,7 @@ import { MemberDialogComponent } from './member-dialog.component';
   styleUrls: ['./members.component.scss']
 })
 export class MembersComponent implements OnInit {
+  members: Member[] = [];
   dataSource = new MatTableDataSource<Member>();
   displayedColumns: string[] = ['name', 'email', 'mobile', 'actions'];
   loading = false;
@@ -46,8 +45,10 @@ export class MembersComponent implements OnInit {
   load() {
     this.loading = true;
     this.memberService.getMembers().subscribe({
-      next: d => this.members = d,
-      next: d => this.dataSource.data = d,
+      next: d => {
+        this.members = d;
+        this.dataSource.data = d;
+      },
       error: () => this.snack.open('Failed to load members', 'Close', { duration: 3000 }),
       complete: () => this.loading = false
     });


### PR DESCRIPTION
## Summary
- move app root markup into a separate HTML template and export the component
- remove duplicate Angular Material imports from `app.module.ts`
- declare missing `members` state and consolidate RxJS subscribe handler
- clean up members template markup and close Material tags

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module '/workspace/onBoardDomain/gym-fees-frontend/src/tsconfig.spec.json')*
- `npm run build -- --progress=false`


------
https://chatgpt.com/codex/tasks/task_e_688f8f9d61e08327ae472efe7754c948